### PR TITLE
[FEATURE] Ability to git ignore only dev packages

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,14 @@ A post-update-cmd script to automatically add Composer managed packages to .giti
 composer require reindeerweb/autogitignore
 ```
 
+### Exclude dev only packages
+Add to the following to your composer.json
+```json
+"extra": {
+ "autogitignore": "devOnly"
+}
+```
+
 ## License
 3-clause BSD license
 See [License](LICENSE)


### PR DESCRIPTION
This patch allows to git ignore only dev packages by adding in the extra configuration   `"autogitignore": "devOnly"`.

This is useful if you need to commit vendor dependencies but still want to exclude local development packages.